### PR TITLE
Replaced bad RNG with a MTwister Pub Domain RNG

### DIFF
--- a/Source/3rdParty/MTwist/include/mtwist.h
+++ b/Source/3rdParty/MTwist/include/mtwist.h
@@ -1,0 +1,59 @@
+/* -*- Mode: c; c-basic-offset: 2 -*-
+ *
+ * mtwist.h - Mersenne Twister header
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ * 
+ */
+
+#ifndef MTWIST_H
+#define MTWIST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Mersenne Twister state */
+typedef struct mtwist_s mtwist;
+
+/* constructor */
+mtwist* mtwist_new(void);
+/* destructor */
+void mtwist_free(mtwist* mt);
+
+/* methods */
+void mtwist_init(mtwist* mt, unsigned long seed);
+unsigned long mtwist_u32rand(mtwist* mt);
+double mtwist_drand(mtwist* mt);
+
+/* utility functions */
+unsigned long mtwist_seed_from_system(mtwist* mt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Source/3rdParty/MTwist/include/mtwist_internal.h
+++ b/Source/3rdParty/MTwist/include/mtwist_internal.h
@@ -1,0 +1,59 @@
+/* -*- Mode: c; c-basic-offset: 2 -*-
+ *
+ * mtwist_internal.c - Mersenne Twister internals
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ * 
+ */
+
+#ifndef MTWIST_INTERNAL_H
+#define MTWIST_INTERNAL_H 1
+
+#define MTWIST_N             624
+#define MTWIST_M             397
+
+#define MT_STATIC_SEED 5489UL
+
+/* Mersenne Twister library state */
+struct mtwist_s {
+  /* MT buffer holding N 32 bit unsigned integers */
+  uint32_t state[MTWIST_N];
+
+  /* Pointer into above - next long to use */
+  uint32_t* next;
+
+  /* Number of remaining integers in state before an update is needed */
+  unsigned int remaining;
+
+  /* 1 if a seed was given */
+  unsigned int seeded : 1;
+
+  /* 1 to always return a static system seed (MT_STATIC_SEED) */
+  unsigned int static_system_seed : 1;
+};
+
+
+#endif

--- a/Source/3rdParty/MTwist/source/mt.c
+++ b/Source/3rdParty/MTwist/source/mt.c
@@ -1,0 +1,219 @@
+/* -*- Mode: c; c-basic-offset: 2 -*-
+ *
+ * mt.c - Mersenne Twister functions
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ * 
+ */
+
+
+#ifdef MTWIST_CONFIG
+#include <mtwist_config.h>
+#endif
+
+#include <stdio.h>
+
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#ifdef HAVE_STDINT_H
+/* To get UINT32_C */
+#define __STDC_CONSTANT_MACROS 1
+#include <stdint.h>
+#else
+/* pessimistic - use an unsigned long */
+typedef unsigned long uint32_t;
+#define UINT32_C(v) (v ## UL)
+#endif
+
+
+#include <mtwist.h>
+
+#include <mtwist_internal.h>
+
+/*
+ * Mersenne Twister (MT19937) algorithm
+ * http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
+ *
+ * http://en.wikipedia.org/wiki/Mersenne_twister
+ *
+ */
+
+#define MTWIST_UPPER_MASK    UINT32_C(0x80000000)
+#define MTWIST_LOWER_MASK    UINT32_C(0x7FFFFFFF)
+#define MTWIST_FULL_MASK     UINT32_C(0xFFFFFFFF)
+
+#define MTWIST_MATRIX_A      UINT32_C(0x9908B0DF)
+
+#define MTWIST_MIXBITS(u, v) ( ( (u) & MTWIST_UPPER_MASK) | ( (v) & MTWIST_LOWER_MASK) )
+#define MTWIST_TWIST(u, v)  ( (MTWIST_MIXBITS(u, v) >> 1) ^ ( (v) & UINT32_C(1) ? MTWIST_MATRIX_A : UINT32_C(0)) )
+
+
+/**
+ * mtwist_new:
+ *
+ * Construct a Mersenne Twister object
+ *
+ * Return value: new MT object or NULL on failure
+ */
+mtwist*
+mtwist_new(void)
+{
+  mtwist* mt;
+  
+  mt = (mtwist*)calloc(1, sizeof(*mt));
+  if(!mt)
+    return NULL;
+  
+  mt->remaining = 0;
+  mt->next = NULL;
+  mt->seeded = 0;
+
+  return mt;
+}
+
+
+/**
+ * mtwist_free:
+ * @mt: mt object
+ *
+ * Destroy a Mersenne Twister object
+ */
+void
+mtwist_free(mtwist* mt) 
+{
+  if(mt)
+    free(mt);
+}
+
+
+/**
+ * mtwist_init:
+ * @mt: mt object
+ * @seed: seed (lower 32 bits used)
+ *
+ * Initialise a Mersenne Twister with an unsigned 32 bit int seed
+ */
+void
+mtwist_init(mtwist* mt, unsigned long seed)
+{
+  int i;
+
+  if(!mt)
+    return;
+  
+  mt->state[0] = (uint32_t)(seed & MTWIST_FULL_MASK);
+  for(i = 1; i < MTWIST_N; i++) {
+    mt->state[i] = (UINT32_C(1812433253) * (mt->state[i - 1] ^ (mt->state[i - 1] >> 30)) + i); 
+    mt->state[i] &= MTWIST_FULL_MASK;
+  }
+
+  mt->remaining = 0;
+  mt->next = NULL;
+
+  mt->seeded = 1;
+}
+
+
+static void
+mtwist_update_state(mtwist* mt)
+{
+  int count;
+  uint32_t *p = mt->state;
+
+  for(count = (MTWIST_N - MTWIST_M + 1); --count; p++)
+    *p = p[MTWIST_M] ^ MTWIST_TWIST(p[0], p[1]);
+
+  for(count = MTWIST_M; --count; p++)
+    *p = p[MTWIST_M - MTWIST_N] ^ MTWIST_TWIST(p[0], p[1]);
+
+  *p = p[MTWIST_M - MTWIST_N] ^ MTWIST_TWIST(p[0], mt->state[0]);
+
+  mt->remaining = MTWIST_N;
+  mt->next = mt->state;
+}
+
+
+/**
+ * mtwist_u32rand:
+ * @mt: mt object
+ *
+ * Get a random unsigned 32 bit integer from the random number generator
+ *
+ * Return value: unsigned long with 32 valid bits
+ */
+unsigned long
+mtwist_u32rand(mtwist* mt)
+{
+  uint32_t r;
+
+  if(!mt)
+    return 0UL;
+
+  if(!mt->seeded)
+    mtwist_init(mt, mtwist_seed_from_system(mt));
+
+  if(!mt->remaining)
+    mtwist_update_state(mt);
+  
+  r = *mt->next++;
+  mt->remaining--;
+
+  /* Tempering */
+  r ^= (r >> 11);
+  r ^= (r << 7) & UINT32_C(0x9D2C5680);
+  r ^= (r << 15) & UINT32_C(0xEFC60000);
+  r ^= (r >> 18);
+
+  r &= MTWIST_FULL_MASK;
+
+  return (unsigned long)r;
+}
+
+
+/**
+ * mtwist_drand:
+ * @mt: mt object
+ *
+ * Get a random double from the random number generator
+ *
+ * Return value: random double in the range 0.0 inclusive to 1.0 exclusive; [0.0, 1.0) */
+double
+mtwist_drand(mtwist* mt)
+{
+  unsigned long r;
+  double d;
+
+  if(!mt)
+    return 0.0;
+
+  r = mtwist_u32rand(mt);
+
+  d = r / 4294967296.0; /* 2^32 */
+
+  return d;
+}

--- a/Source/3rdParty/MTwist/source/seed.c
+++ b/Source/3rdParty/MTwist/source/seed.c
@@ -1,0 +1,99 @@
+/* -*- Mode: c; c-basic-offset: 2 -*-
+ *
+ * seed.c - Seeding functions
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * For more information, please refer to <http://unlicense.org/>
+ * 
+ */
+
+#ifdef MTWIST_CONFIG
+#include <mtwist_config.h>
+#endif
+
+#include <stdio.h>
+
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_STDINT_H
+#include <stdint.h>
+#else
+/* pessimistic - use an unsigned long */
+typedef unsigned long uint32_t;
+#endif
+
+#include <mtwist.h>
+
+#include <mtwist_internal.h>
+
+
+/**
+ * mtwist_seed_from_system:
+ * @mt: mt object
+ *
+ * Get a 32 bit unsigned integer random seed based on system sources
+ *
+ * Return value: seed with only lower 32 bits valid
+ */
+unsigned long
+mtwist_seed_from_system(mtwist* mt)
+{
+  /* SOURCE 1: processor clock ticks since process started */
+  uint32_t a = (uint32_t)clock();
+  /* SOURCE 2: unix time in seconds since epoch */
+  uint32_t b = (uint32_t)time(NULL);
+  uint32_t c;
+#ifdef HAVE_UNISTD_H
+  /* SOURCE 3: process ID (on unix) */
+  c = getpid();
+#else
+  c = 0;
+#endif
+  
+  /* Mix seed sources using public domain code from
+   * http://www.burtleburtle.net/bob/c/lookup3.c
+   */
+
+#define rot(x,k) (((x)<<(k)) | ((x)>>(32-(k))))
+  
+  /* inlined mix(a, b, c) macro */
+  a -= c;  a ^= rot(c, 4);  c += b;
+  b -= a;  b ^= rot(a, 6);  a += c;
+  c -= b;  c ^= rot(b, 8);  b += a;
+  a -= c;  a ^= rot(c,16);  c += b;
+  b -= a;  b ^= rot(a,19);  /* a += c; */ /* CLANG: not needed because of below */
+  c -= b;  c ^= rot(b, 4);  /* b += a; */ /* CLANG: last calculation not needed */
+
+  if(mt->static_system_seed)
+    c = MT_STATIC_SEED;
+
+  return (unsigned long)c;
+}

--- a/Source/Snake/include/ApplicationLayer/InputController.hpp
+++ b/Source/Snake/include/ApplicationLayer/InputController.hpp
@@ -1,0 +1,16 @@
+// Written by Joshua Lollis @Tello-
+// 11.28.19
+
+/* This file is planned to convert player input into commands*/
+
+#pragma once
+
+#include <SFML/System.hpp>
+
+
+class InputController
+{
+public:
+	InputController() = delete;
+private:
+};

--- a/Source/Snake/include/Game.h
+++ b/Source/Snake/include/Game.h
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <SFML/Graphics.hpp>
 #include "World.hpp"
 #include "Snake.hpp"
 #include "GameText.hpp"
@@ -9,8 +10,6 @@
 
 const unsigned WINDOW_X{ 600 };
 const unsigned WINDOW_Y{ 600 };
-
-
 
 enum State {PENDING, PLAYING, PAUSED, LOSE};
 class Game

--- a/Source/Snake/include/World.hpp
+++ b/Source/Snake/include/World.hpp
@@ -1,7 +1,8 @@
 #pragma once
+#include <time.h>
+#include <mtwist.h>
 #include "SFML/Graphics.hpp"
 #include "Snake.hpp"
-
 
 
 class World
@@ -9,6 +10,7 @@ class World
 
 public:
 	World(sf::Vector2u _windowSize);
+	~World();
 
 	
 	void Update();
@@ -28,5 +30,6 @@ private:
 	sf::CircleShape m_apple;
 	sf::Vector2i m_applePosition;
 	Snake m_snake;
+	mtwist* m_pMTState;
 
 };

--- a/Source/Snake/include/mtrng.h
+++ b/Source/Snake/include/mtrng.h
@@ -1,0 +1,1 @@
+#pragma once

--- a/Source/Snake/source/World.cpp
+++ b/Source/Snake/source/World.cpp
@@ -1,4 +1,5 @@
 #include "..\include\World.hpp"
+#include <iostream>
 
 World::World(sf::Vector2u _windowSize) 
 	: m_windowSize{ _windowSize }, m_blockSize{ _windowSize.x / 25 }, m_snake{ getBlockSize(), sf::Vector2i{(int)m_windowSize.x / 2, (int)m_windowSize.y / 2} }
@@ -7,14 +8,28 @@ World::World(sf::Vector2u _windowSize)
 	m_apple.setOutlineColor(sf::Color(31, 63, 54, 255));
 	m_apple.setOutlineThickness(-2);
 	m_apple.setRadius(static_cast<float>(m_blockSize) / 2.f);
+
+	m_pMTState = mtwist_new();
+	std::cout << m_pMTState << std::endl;
+	auto seed = mtwist_seed_from_system(m_pMTState);
+	std::cout << "Seed: " << seed << std::endl;
+	mtwist_init(m_pMTState, seed);
+
+	
+
 	//SpawnApple();
+}
+
+World::~World()
+{
+	mtwist_free(m_pMTState);
 }
 
 void World::SpawnApple()
 {
 	int maxX = (m_windowSize.x / m_blockSize) - 2;
 	int maxY = (m_windowSize.y / m_blockSize) - 2;
-	m_applePosition = sf::Vector2i(rand() % maxX + 1, rand() % maxY + 1);
+	m_applePosition = sf::Vector2i(mtwist_u32rand(m_pMTState) % maxX + 1, mtwist_u32rand(m_pMTState) % maxY + 1);
 	m_apple.setPosition(static_cast<float>(m_applePosition.x * m_blockSize), static_cast<float>(m_applePosition.y * m_blockSize));
 }
 


### PR DESCRIPTION
Took out the lack of actual RNG for the apple coordinates and replaced it with a public domaine implementation of the Mersenne Twister method of RNG. Works great. One thing to note is that I'm not sure if and when the RNG state will reach its last value and if this is something handled automatically in the code or I need to guard for this and re-seed as needed.